### PR TITLE
Update 09-student-guide.Rmd

### DIFF
--- a/09-student-guide.Rmd
+++ b/09-student-guide.Rmd
@@ -15,10 +15,11 @@ Make sure you have an AnVIL account (refer to https://jhudatascience.org/AnVIL_B
 This activity will teach you how to use the AnVIL platform to:
 
 1. Get started working on AnVIL
-1. Launch the Galaxy tool
-1. Examine fastq sequence data files
-1. Align sequence data to a reference genome
-1. View the aligned data and reference genomes interactively
+2. Launch the Galaxy tool
+3. Import data into the Galaxy tool
+4. Examine fastq sequence data files
+5. Align sequence data to a reference genome
+6. View the aligned data and reference genomes interactively
 
 ## Getting Started
 
@@ -74,7 +75,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/182AOzMaiyrreinns
 
 On the welcome page, there are links to tutorials. You may try these out on your own. If you want to try a new analysis this is a good place to start.
 
-### Importing Data into Galaxy
+## Exercise One: Importing Data into Galaxy
 
 Luckily, we linked to the original data when we cloned our Workspace! We have three files we will need for our activity. These are (1) the reference genome for SARS-CoV-2, and both forward (2) and reverse (3) reads for our sample. There are two sets of reads for our sample because the scientists who collected it used paired-end sequencing. The reference genome ends in “.fasta” because it has already been cleaned up by scientists. The sample we are looking at ends in `fastq` because it is raw data from the sequencer.
 
@@ -104,7 +105,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/182AOzMaiyrreinns
 ottrpal::include_slide("https://docs.google.com/presentation/d/182AOzMaiyrreinnsRX2VhH7YsVgvAp4xtIB_7Mzmk6I/edit#slide=id.ged15532ded_0_861")
 ```
 
-## Exercise One: Examining `fastq` Files in Galaxy
+## Exercise Two: Examining `fastq` Files in Galaxy
 
 _Now we have some data in our account we can look at it. In this exercise we will see data in `fastq` format. This is the typical output from an Illumina Sequencer, but also the standard format for most alignment software._
 
@@ -181,7 +182,7 @@ Q = -10 log10(P)
 Using this formula, we can calculate that a quality score of 40 means only 0.00010 probability of an error!
 :::
 
-## Exercise Two: Alignment {#exercise-two}
+## Exercise Three: Alignment {#exercise-three}
 
 _Given that our data has passed some quality checks, we will try to align the data to the reference genome. In this case it is simple, a viral genome. A human sequencing project will generate much larger data sets. There are many aligners, but we will start off looking at a simple aligner BWA-MEM. This example uses paired data._ 
 
@@ -217,7 +218,7 @@ QUESTIONS:
 8. Here we are using paired fastq (“paired end”) data. What is an advantage of using paired data?
 :::
 
-## Exercise Three: Viewing aligned data
+## Exercise Four: Viewing aligned data
 
 We have aligned our data but it is currently a table of where the reads align. This is hard to read, so we will use JBrowse to view the data.
 
@@ -235,7 +236,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/182AOzMaiyrreinns
 
 This is interesting, but it doesn’t let us compare the genome to the sample we have. We suspect there may be some differences that indicate our sample is the delta variant. Go back to STATISTICS AND VISUALIZATION: Graph/Display Data and select "JBrowse". Just like before, under "Reference genome to display", ensure that “Use a genome from history” is selected. Below this, make sure that the **SARS-CoV-2_reference_genome.fasta** file is selected. 
 
-This time, we’ll add our alignment data from [Exercise Two](#exercise-two). Click the “+ Insert Track Group” button. 
+This time, we’ll add our alignment data from [Exercise Three](#exercise-three). Click the “+ Insert Track Group” button. 
 
 ```{r, echo=FALSE, fig.alt='Screenshot of JBrowse options. The “+ Insert Track Group” button is highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/182AOzMaiyrreinnsRX2VhH7YsVgvAp4xtIB_7Mzmk6I/edit#slide=id.gf243efded1_0_83")


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?



#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Publishing-with-Bookdown).

- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Using-Docker#adding-packages-to-the-dockerfile).

- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).

- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
